### PR TITLE
update Amplitude v2.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.amplitude:android-sdk:2.5.0'
+  compile 'com.amplitude:android-sdk:2.5.1'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {


### PR DESCRIPTION
This is an important patch for a bug in our SDK. Please push this as soon as you can. Details on the bug here: https://github.com/amplitude/Amplitude-Android/pull/83.

Thanks!