### PR TITLE
update Amplitude android v2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.amplitude:android-sdk:2.5.1'
+  compile 'com.amplitude:android-sdk:2.6.0'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {


### PR DESCRIPTION
update Amplitude Android to [v2.6.0](https://github.com/amplitude/Amplitude-Android/releases/tag/v2.6.0), replaces the now deprecated v2.5.1

Important bug patch: fix bug where merging events for upload causes array index out of bounds exception crash. Issue: https://github.com/amplitude/Amplitude-Android/issues/90

Semi-important updates:
* Update to OKHttp v3.0.1.
* Migrate shared preferences (userId and event meta data) to Sqlite db to support apps with multiple processes.

Non-important updates:
* Add support for prepend user property operation.