### PR TITLE
updates Amplitude SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.amplitude:android-sdk:2.6.0'
+  compile 'com.amplitude:android-sdk:2.7.1'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {


### PR DESCRIPTION
Amplitude 2.7.0 fixes crash when trying to enableForegroundTracking:
https://github.com/amplitude/Amplitude-Android/blob/master/CHANGELOG.md#270-april-19-2016

@f2prateek 👀 