### PR TITLE
update amplitude v2.9.2 with logRevenueV2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.amplitude:android-sdk:2.7.1'
+  compile 'com.amplitude:android-sdk:2.9.2'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {


### PR DESCRIPTION
I know the branch name says v2.9.1, but we had to push a fix to get one of the Segment tests working.

This updates Amplitude Android SDK to v2.9.2. This is mainly to update revenue handling. This allows people to also set a revenueType field, as well as capture event properties with the revenue event.

This is potentially api-breaking due to a mismatch between Segment's ecommerce API and our revenue API. Before this update, if the quantity was > 1, then we would actually multiply revenue * quantity to get the final revenue. But now we recognize the top-level "revenue" field to be the entire amount of the revenue event (price * quantity). We now also recognize top-level price and quantity fields. If those 2 are set, then we will take those over the revenue field (in theory revenue should = price * quantity). If either one of those 2 fields are missing, then we just use the revenue as the price field with quantity = 1 (even if they define quantity > 1). With our new definitions it doesn't make sense to have a revenue and a quantity, but no price field.

Other updates:
* Adds automatic flushing of events on app close/minimize
* Run initialization logic on background thread to minimize time on main thread