### PR TITLE
only send revenue event if event has revenue

### DIFF
--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -155,6 +155,18 @@ public class AmplitudeTest {
             .setReceipt("baz", "qux")
             .setEventProperties(properties.toJsonObject());
     verify(amplitude).logRevenueV2(revenueEq(expectedRevenue));
+
+    // third case has price but no revenue
+    properties = new Properties().putValue("productId", "bar")
+            .putValue("quantity", 10)
+            .putValue("price", 2.00)
+            .putValue("receipt", "baz")
+            .putValue("receiptSignature", "qux");
+    trackPayload = new TrackPayloadBuilder().event("foo").properties(properties).build();
+    integration.track(trackPayload);
+    verify(amplitude).logEvent(eq("foo"), jsonEq(properties.toJsonObject()));
+
+    verifyNoMoreInteractions(amplitude);
   }
 
   @Test public void identify() {


### PR DESCRIPTION
Similar to https://github.com/segment-integrations/integration-amplitude/pull/20, we need to fix a bug introduced with this merge: https://github.com/segment-integrations/analytics-android-integration-amplitude/pull/11/files.

Basically there are cases when customers want to track price as a property, without intending to track it as revenue. We should only explicitly pull the price when the event has revenue.

@f2prateek if you could release this ASAP that would be greatly appreciated. Thanks! (This is the last of the PRs for this bug fix)
