### PR TITLE
Fix reset method to call regenerateDeviceId.

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -173,7 +173,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
   @Override public void reset() {
     super.reset();
 
-    amplitude.clearUserProperties();
-    logger.verbose("AmplitudeClient.getInstance().clearUserProperties();");
+    amplitude.regenerateDeviceId();
+    logger.verbose("AmplitudeClient.getInstance().regenerateDeviceId();");
   }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -33,6 +33,7 @@ import static com.segment.analytics.Utils.createTraits;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -246,7 +247,10 @@ public class AmplitudeTest {
   @Test public void reset() {
     integration.reset();
 
-    verify(amplitude).clearUserProperties();
+    verify(amplitude).regenerateDeviceId();
+
+    // Previously we called clearUserProperties() which was incorrect.
+    verify(amplitude, never()).clearUserProperties();
   }
 
   private void verifyAmplitudeLoggedEvent(String event, JSONObject jsonObject) {


### PR DESCRIPTION
Previously we were calling clearUserProperties() which was incorrect.
Updated as per Amplitude's suggestion.