### PR TITLE
update amplitude android sdk v2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     compile 'com.android.support:support-annotations:25.3.1'
 
-    compile 'com.amplitude:android-sdk:2.13.4'
+    compile 'com.amplitude:android-sdk:2.15.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.3.1'


### PR DESCRIPTION
Updating Amplitude Android SDK to v2.15.0 (https://github.com/amplitude/Amplitude-Android/blob/master/CHANGELOG.md)