### PR TITLE
Add/setting enable location listening

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -93,9 +93,9 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
     amplitude.trackSessionEvents(trackSessionEvents);
     logger.verbose("AmplitudeClient.getInstance().trackSessionEvents(%s);", trackSessionEvents);
 
-    boolean enableLocationListening = settings.getBoolean("enableLocationListening", false);
-    if (enableLocationListening) {
-      amplitude.enableLocationListening();
+    boolean enableLocationListening = settings.getBoolean("enableLocationListening", true);
+    if (!enableLocationListening) {
+      amplitude.disableLocationListening();
     }
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -92,6 +92,11 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
     boolean trackSessionEvents = settings.getBoolean("trackSessionEvents", false);
     amplitude.trackSessionEvents(trackSessionEvents);
     logger.verbose("AmplitudeClient.getInstance().trackSessionEvents(%s);", trackSessionEvents);
+
+    boolean enableLocationListening = settings.getBoolean("enableLocationListening", false);
+    if (enableLocationListening) {
+      amplitude.enableLocationListening();
+    }
   }
 
   @Override

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -84,7 +84,8 @@ public class AmplitudeTest {
         new ValueMap().putValue("apiKey", "foo")
             .putValue("trackAllPages", true)
             .putValue("trackCategorizedPages", false)
-            .putValue("trackNamedPages", true));
+            .putValue("trackNamedPages", true)
+            .putValue("enableLocationListening", true));
 
     assertThat(integration.trackAllPages).isTrue();
     assertThat(integration.trackCategorizedPages).isFalse();
@@ -93,6 +94,7 @@ public class AmplitudeTest {
     verify(amplitude).initialize(application, "foo");
     verify(amplitude).enableForegroundTracking(application);
     verify(amplitude).trackSessionEvents(false);
+    verify(amplitude).enableLocationListening();
   }
 
   @Test

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -92,7 +92,7 @@ public class AmplitudeTest {
             .putValue("trackAllPages", true)
             .putValue("trackCategorizedPages", false)
             .putValue("trackNamedPages", true)
-            .putValue("enableLocationListening", false));
+            .putValue("enableLocationListening", false)
             .putValue("useAdvertisingIdForDeviceId", true));
 
     assertThat(integration.trackAllPagesV2).isTrue();

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -85,7 +85,7 @@ public class AmplitudeTest {
             .putValue("trackAllPages", true)
             .putValue("trackCategorizedPages", false)
             .putValue("trackNamedPages", true)
-            .putValue("enableLocationListening", true));
+            .putValue("enableLocationListening", false));
 
     assertThat(integration.trackAllPages).isTrue();
     assertThat(integration.trackCategorizedPages).isFalse();
@@ -94,7 +94,7 @@ public class AmplitudeTest {
     verify(amplitude).initialize(application, "foo");
     verify(amplitude).enableForegroundTracking(application);
     verify(amplitude).trackSessionEvents(false);
-    verify(amplitude).enableLocationListening();
+    verify(amplitude).disableLocationListening();
   }
 
   @Test


### PR DESCRIPTION
Location listening is enabled by default, so we should give users the option to disable it on initialization via a Segment setting.