### PR TITLE
Add support for trackAllPagesV2 and add tests

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -60,6 +60,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
   private final Logger logger;
   // mutable for testing.
   boolean trackAllPages;
+  boolean trackAllPagesV2;
   boolean trackCategorizedPages;
   boolean trackNamedPages;
   boolean useLogRevenueV2;
@@ -86,6 +87,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
   AmplitudeIntegration(Provider provider, Analytics analytics, ValueMap settings) {
     amplitude = provider.get();
     trackAllPages = settings.getBoolean("trackAllPages", false);
+    trackAllPagesV2 = settings.getBoolean("trackAllPagesV2", true);
     trackCategorizedPages = settings.getBoolean("trackCategorizedPages", false);
     trackNamedPages = settings.getBoolean("trackNamedPages", false);
     useLogRevenueV2 = settings.getBoolean("useLogRevenueV2", false);
@@ -178,7 +180,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       Object value = entry.getValue();
       if (traitsToIncrement.contains(key)) {
         incrementTrait(key, value, identify);
-      } else if(traitsToSetOnce.contains(key)) {
+      } else if (traitsToSetOnce.contains(key)) {
         setOnce(key, value, identify);
       } else {
         setTrait(key, value, identify);
@@ -260,6 +262,14 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
   @Override
   public void screen(ScreenPayload screen) {
     super.screen(screen);
+    if (trackAllPagesV2) {
+      Properties properties = new Properties();
+      properties.putAll(screen.properties());
+      properties.put("name", screen.name());
+      event("Loaded a Screen", properties, null, null);
+      return;
+    }
+
     if (trackAllPages) {
       event(String.format(VIEWED_EVENT_FORMAT, screen.event()), screen.properties(), null, null);
     } else if (trackCategorizedPages && !isNullOrEmpty(screen.category())) {

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -500,8 +500,10 @@ public class AmplitudeTest {
 
   @Test
   public void screenTrackAllPagesV2() throws JSONException {
-    integration.screen(new ScreenPayloadBuilder().name("foo").build());
-    verifyAmplitudeLoggedEvent("Loaded a Screen", new JSONObject().put("name", "foo"));
+    Properties properties = new Properties();
+    properties.putValue("bar", "baz");
+    integration.screen(new ScreenPayloadBuilder().name("foo").properties(properties).build());
+    verifyAmplitudeLoggedEvent("Loaded a Screen", new JSONObject().put("name", "foo").put("bar", "baz"));
   }
 
   @Test

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -88,12 +88,14 @@ public class AmplitudeTest {
   public void initialize() {
     integration = new AmplitudeIntegration(mockProvider, analytics,
         new ValueMap().putValue("apiKey", "foo")
+            .putValue("trackAllPagesV2", true)
             .putValue("trackAllPages", true)
             .putValue("trackCategorizedPages", false)
             .putValue("trackNamedPages", true)
             .putValue("enableLocationListening", true)
             .putValue("useAdvertisingIdForDeviceId", true));
 
+    assertThat(integration.trackAllPagesV2).isTrue();
     assertThat(integration.trackAllPages).isTrue();
     assertThat(integration.trackCategorizedPages).isFalse();
     assertThat(integration.trackNamedPages).isTrue();
@@ -441,6 +443,7 @@ public class AmplitudeTest {
 
   @Test
   public void screen() {
+    integration.trackAllPagesV2 = false;
     integration.trackAllPages = false;
     integration.trackCategorizedPages = false;
     integration.trackNamedPages = false;
@@ -452,6 +455,7 @@ public class AmplitudeTest {
 
   @Test
   public void screenTrackNamedPages() {
+    integration.trackAllPagesV2 = false;
     integration.trackAllPages = false;
     integration.trackCategorizedPages = false;
     integration.trackNamedPages = true;
@@ -465,6 +469,7 @@ public class AmplitudeTest {
 
   @Test
   public void screenTrackCategorizedPages() {
+    integration.trackAllPagesV2 = false;
     integration.trackAllPages = false;
     integration.trackCategorizedPages = true;
     integration.trackNamedPages = false;
@@ -478,6 +483,7 @@ public class AmplitudeTest {
 
   @Test
   public void screenTrackAllPages() {
+    integration.trackAllPagesV2 = false;
     integration.trackAllPages = true;
     integration.trackCategorizedPages = false;
     integration.trackNamedPages = false;
@@ -490,6 +496,12 @@ public class AmplitudeTest {
 
     integration.screen(new ScreenPayloadBuilder().category("bar").name("baz").build());
     verifyAmplitudeLoggedEvent("Viewed baz Screen", new JSONObject());
+  }
+
+  @Test
+  public void screenTrackAllPagesV2() throws JSONException {
+    integration.screen(new ScreenPayloadBuilder().name("foo").build());
+    verifyAmplitudeLoggedEvent("Loaded a Screen", new JSONObject().put("name", "foo"));
   }
 
   @Test


### PR DESCRIPTION
- `trackAllPagesV2` defaults to true
- triggers a "Loaded a Screen" event
- adds the screen name as a `logEvent` property so customers can build funnels based on screen name - this was requested by IBM, and this functionality also reflects how we handle screen names in Mixpanel for Android's `consolidatedPageCalls` setting
- if enabled, `trackAllPagesV2` overrides any other page settings (using an early return)

Satisfies JIRA issue: https://segment.atlassian.net/browse/PLATFORM-1644