### PR TITLE
Update/out of session logic

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -178,7 +178,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       Object value = entry.getValue();
       if (traitsToIncrement.contains(key)) {
         incrementTrait(key, value, identify);
-      } else if(traitsToSetOnce.contains(key)) {
+      } else if (traitsToSetOnce.contains(key)) {
         setOnce(key, value, identify);
       } else {
         setTrait(key, value, identify);
@@ -303,13 +303,8 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       @Nullable Map options,
       @Nullable JSONObject groups) {
     JSONObject propertiesJSON = properties.toJsonObject();
-    boolean outOfSession = false;
+    boolean outOfSession = getOptOutOfSessionFromOptions(options);
 
-    if (!isNullOrEmpty(options)) {
-      if (options.containsKey("outOfSession") && options.get("outOfSession") != null && options.get("outOfSession") instanceof Boolean) {
-        outOfSession = (Boolean) options.get("outOfSession");
-      }
-    }
     amplitude.logEvent(name, propertiesJSON, groups, outOfSession);
     logger.verbose(
         "AmplitudeClient.getInstance().logEvent(%s, %s, %s, %s);",
@@ -323,6 +318,19 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
         logRevenueV1(properties);
       }
     }
+  }
+
+  private boolean getOptOutOfSessionFromOptions(Map options) {
+    boolean outOfSession = false;
+
+    if (!isNullOrEmpty(options)) {
+      if (options.containsKey("outOfSession")
+          && options.get("outOfSession") != null
+          && options.get("outOfSession") instanceof Boolean) {
+        outOfSession = (Boolean) options.get("outOfSession");
+      }
+    }
+    return outOfSession;
   }
 
   @SuppressWarnings("deprecation")

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -1,9 +1,8 @@
 package com.segment.analytics.android.integrations.amplitude;
 
-import static com.segment.analytics.internal.Utils.isNullOrEmpty;
-
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+
 import com.amplitude.api.Amplitude;
 import com.amplitude.api.AmplitudeClient;
 import com.amplitude.api.Identify;
@@ -20,16 +19,17 @@ import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
 /**
  * Amplitude is an event tracking and segmentation tool for your mobile apps. By analyzing the

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -323,7 +323,11 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
     if (isNullOrEmpty(options)) {
       return false;
     }
-    if (options.containsKey("outOfSession") && options.get("outOfSession") instanceof Boolean) {
+    Object outOfSession = options.get("outOfSession");
+    if (outOfSession == null) {
+      return false;
+    }
+    if (outOfSession instanceof Boolean) {
       return (Boolean) options.get("outOfSession");
     }
     return false;

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -320,13 +320,11 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
     }
   }
 
-  private boolean getOptOutOfSessionFromOptions(Map options) {
+  private boolean getOptOutOfSessionFromOptions(@Nullable Map options) {
     boolean outOfSession = false;
 
     if (!isNullOrEmpty(options)) {
-      if (options.containsKey("outOfSession")
-          && options.get("outOfSession") != null
-          && options.get("outOfSession") instanceof Boolean) {
+      if (options.containsKey("outOfSession") && options.get("outOfSession") instanceof Boolean) {
         outOfSession = (Boolean) options.get("outOfSession");
       }
     }

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -306,7 +306,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
     boolean outOfSession = false;
 
     if (!isNullOrEmpty(options)) {
-      if (options.containsKey("outOfSession") && options.get("outOfSession") != null) {
+      if (options.containsKey("outOfSession") && options.get("outOfSession") != null && options.get("outOfSession") instanceof Boolean) {
         outOfSession = (Boolean) options.get("outOfSession");
       }
     }

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -303,12 +303,11 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       @Nullable Map options,
       @Nullable JSONObject groups) {
     JSONObject propertiesJSON = properties.toJsonObject();
-    boolean outOfSession = getOptOutOfSessionFromOptions(options);
 
-    amplitude.logEvent(name, propertiesJSON, groups, outOfSession);
+    amplitude.logEvent(name, propertiesJSON, groups, getOptOutOfSessionFromOptions(options));
     logger.verbose(
         "AmplitudeClient.getInstance().logEvent(%s, %s, %s, %s);",
-        name, propertiesJSON, groups, outOfSession);
+        name, propertiesJSON, groups, getOptOutOfSessionFromOptions(options));
 
     // use containsKey since revenue and total can have negative values.
     if (properties.containsKey("revenue") || properties.containsKey("total")) {
@@ -321,14 +320,13 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
   }
 
   private boolean getOptOutOfSessionFromOptions(@Nullable Map options) {
-    boolean outOfSession = false;
-
-    if (!isNullOrEmpty(options)) {
-      if (options.containsKey("outOfSession") && options.get("outOfSession") instanceof Boolean) {
-        outOfSession = (Boolean) options.get("outOfSession");
-      }
+    if (isNullOrEmpty(options)) {
+      return false;
     }
-    return outOfSession;
+    if (options.containsKey("outOfSession") && options.get("outOfSession") instanceof Boolean) {
+      return (Boolean) options.get("outOfSession");
+    }
+    return false;
   }
 
   @SuppressWarnings("deprecation")

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -192,6 +192,55 @@ public class AmplitudeTest {
   }
 
   @Test
+  public void trackOutOfSessionOptionsNull() {
+    Properties properties = new Properties();
+
+    integration.track(new TrackPayloadBuilder()
+            .event("foo")
+            .properties(properties)
+            .build());
+
+    verify(amplitude)
+            .logEvent(eq("foo"), jsonEq(properties.toJsonObject()), isNull(JSONObject.class), eq(false));
+  }
+
+  @Test
+  public void trackOutOfSessionNotInstanceOfBoolean() {
+    Properties properties = new Properties();
+
+    integration.track(new TrackPayloadBuilder()
+            .event("foo")
+            .properties(properties)
+            .options(new Options()
+                    .setIntegrationOptions("Amplitude", new ValueMap()
+                            .putValue("outOfSession", "string")
+                    )
+            )
+            .build());
+
+    verify(amplitude)
+            .logEvent(eq("foo"), jsonEq(properties.toJsonObject()), isNull(JSONObject.class), eq(false));
+  }
+
+  @Test
+  public void trackOutOfSessionKeyNotSet() {
+    Properties properties = new Properties();
+
+    integration.track(new TrackPayloadBuilder()
+            .event("foo")
+            .properties(properties)
+            .options(new Options()
+                    .setIntegrationOptions("Amplitude", new ValueMap()
+                            .putValue("randomSetting", "testing")
+                    )
+            )
+            .build());
+
+    verify(amplitude)
+            .logEvent(eq("foo"), jsonEq(properties.toJsonObject()), isNull(JSONObject.class), eq(false));
+  }
+
+  @Test
   public void trackWithRevenue() {
     Properties properties = new Properties().putRevenue(20)
         .putValue("productId", "bar")


### PR DESCRIPTION
- Updates outOfSession logic to guard against outOfSession option that is not of data type `boolean`
- Updates tests: 
-- If `options` is null - `outOfSession` should be false
-- If `outOfSession` option is set to true and is of type boolean - `outOfSession` should be true
-- If `outOfSession` is not null and is not of type boolean - `outOfSession` should be false
-- If `options` is not null but doesn't contain `outOfSession` flag - `outOfSession` should be false