### PR TITLE
[FCD-207] Implement groupIdentify to track group properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     }
 
     api 'com.segment.analytics.android:analytics:4.3.1'
-    api 'com.amplitude:android-sdk:2.19.1'
+    api 'com.amplitude:android-sdk:2.21.0'
 
     testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
     testImplementation 'junit:junit:4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=3.0.0-SNAPSHOT
+VERSION=3.0.1-SNAPSHOT
 
 POM_ARTIFACT_ID=amplitude
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -167,7 +167,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       String key = it.next();
       try {
         Object value = groups.get(key);
-        setGroup(key, value);
+        amplitude.setGroup(key, value);
       } catch (JSONException e) {
         logger.error(e, "error reading %s from %s", key, groups);
       }
@@ -409,13 +409,17 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       groupName = "[Segment] Group";
     }
 
-    assert groupName != null;
-    setGroup(groupName, groupValue);
-  }
-
-  private void setGroup(@NonNull String groupName, @NonNull Object groupValue) {
+    // Set group
     amplitude.setGroup(groupName, groupValue);
-    logger.verbose("AmplitudeClient.getInstance().setGroup(%s, %s);", groupName, groupValue);
+
+    // Set group properties
+    Identify groupIdentify = new Identify();
+    groupIdentify.set("library", "segment");
+    if (!isNullOrEmpty(traits)) {
+      groupIdentify.set("group_properties", traits.toJsonObject());
+    }
+
+    amplitude.groupIdentify(groupName, groupValue, groupIdentify);
   }
 
   @Override

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -609,20 +609,31 @@ public class AmplitudeTest {
 
     integration.group(payload);
 
+    Identify expectedIdentify = new Identify();
+    expectedIdentify.set("library", "segment");
+
     verify(amplitude).setGroup("[Segment] Group", "testGroupId");
+    verify(amplitude).groupIdentify(eq("[Segment] Group"), eq("testGroupId"), identifyEq(expectedIdentify));
   }
 
   @Test
   public void groupWithGroupName() {
+    Traits traits = new Traits().putName("testName");
+
     GroupPayload payload = (new GroupPayload.Builder())
             .userId("foo")
         .groupId("testGroupId")
-        .traits(new Traits().putName("testName"))
+        .traits(traits)
         .build();
 
     integration.group(payload);
 
+    Identify expectedIdentify = new Identify();
+    expectedIdentify.set("library", "segment");
+    expectedIdentify.set("group_properties", traits.toJsonObject());
+
     verify(amplitude).setGroup("testName", "testGroupId");
+    verify(amplitude).groupIdentify(eq("testName"), eq("testGroupId"), identifyEq(expectedIdentify));
   }
 
   @Test
@@ -630,15 +641,22 @@ public class AmplitudeTest {
     integration.groupTypeTrait = "company";
     integration.groupValueTrait = "companyType";
 
+    Traits traits = new Traits().putValue("company", "Segment").putValue("companyType", "data").putValue("members", 80);
+
     GroupPayload payload = (new GroupPayload.Builder())
             .userId("foo")
         .groupId("testGroupId")
-        .traits(new Traits().putValue("company", "Segment").putValue("companyType", "data"))
+        .traits(traits)
         .build();
 
     integration.group(payload);
 
+    Identify expectedIdentify = new Identify();
+    expectedIdentify.set("library", "segment");
+    expectedIdentify.set("group_properties", traits.toJsonObject());
+
     verify(amplitude).setGroup("Segment", "data");
+    verify(amplitude).groupIdentify(eq("Segment"), eq("data"), identifyEq(expectedIdentify));
   }
 
   @Test


### PR DESCRIPTION
[FCD-207](https://segment.atlassian.net/browse/FCD-207)

For parity with the [server-side](https://github.com/segmentio/integrations/blob/master/integrations/amplitude/lib/mapper.js#L316-L353) implementation, we now track group properties with [AMPIdentify](https://amplitude.zendesk.com/hc/en-us/articles/115002935588-Android-SDK-Installation#setting-group-properties).

We required to bump the SDK version because this feature was added in `2.20.0`.