### PR TITLE
Brie/sdk bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     resource_class: small
     docker:
-      - image: circleci/android:api-28
+      - image: circleci/android:api-28-alpha
         environment:
           ANDROID_HOME: /home/circleci/android
           CIRCLE_JDK_VERSION: oraclejdk8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     resource_class: small
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-28
         environment:
           ANDROID_HOME: /home/circleci/android
           CIRCLE_JDK_VERSION: oraclejdk8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     resource_class: small
     docker:
-      - image: circleci/android:api-25-alpha
+      - image: circleci/android:api-28
         environment:
           ANDROID_HOME: /home/circleci/android
           CIRCLE_JDK_VERSION: oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+3.0.2 / 2019-09-16
+==================
+
+  * [DEST-929] Update Android Ampltiude SDK
+    * Update Amplitude SDK to 2.23.1
 
 3.0.1 / 2019-01-10
 ==================

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     }
 
     api 'com.segment.analytics.android:analytics:4.3.1'
-    api 'com.amplitude:android-sdk:2.21.0'
+    api 'com.amplitude:android-sdk:2.23.1'
 
     testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
     testImplementation 'junit:junit:4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=3.0.1-SNAPSHOT
+VERSION=3.0.2-SNAPSHOT
 
 POM_ARTIFACT_ID=amplitude
 POM_PACKAGING=jar


### PR DESCRIPTION
**What does this PR do?**
This PR bumps the SDK from 2.21.0 to 2.23.1 

**Are there breaking changes in this PR?**
No, the SDK still compiles as expected and all tests pass locally. 

**Any background context you want to provide?**
Recent Amplitude SDK releases include changes to: 
- Handle SQLite database crashes caused by fetching events that exceed 2MB (max size of cursor window).
- Make startNewSessionIfNeeded a public method. Only call this if you know what you are doing. This may trigger a new session to start.
- Store deviceId in SharedPreferences as backup in case SQLite database fails or becomes corrupted.
- Add ability to set a custom server URL for uploading events using setServerUrl.

NOTE: These new releases do not look like they introduce any new breaking changes. 

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
No

**What are the relevant tickets?**
[DEST-929](https://segment.atlassian.net/browse/DEST-929)

**Link to CC ticket**
N/A
