### PR TITLE
DAND-10-Fix: Bump amplitude sdk from 2.23.1 to 2.23.2 and mockito to …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ gradle-app.setting
 
 .project
 .classpath
+*.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -50,12 +50,12 @@ dependencies {
     }
 
     api 'com.segment.analytics.android:analytics:4.3.1'
-    api 'com.amplitude:android-sdk:2.23.1'
+    api 'com.amplitude:android-sdk:2.23.2'
 
     testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.android.support.test:runner:1.0.2'
-    testImplementation 'org.mockito:mockito-core:2.22.0'
+    testImplementation 'org.mockito:mockito-core:3.1.0'
 
     // Required for local (non-android) testing
     testImplementation 'org.json:json:20180813'


### PR DESCRIPTION

**What does this PR do?**
This PR:
Bumps the Amplitude dependency version from 2.23.1 to 2.23.2
Bumps the Mockito dependency version from 2.22.0 to 3.1.0

**Are there breaking changes in this PR?**
Compiled Successfully and All test passed


**What are the relevant tickets?**
 Jira ticket : [#DEST-1328](https://segmentcontractors.atlassian.net/jira/software/projects/DAND/boards/1?selectedIssue=DAND-10)

**Link to CC ticket**

