### PR TITLE
support string array traits when either traitsToIncrement or traitsToSetOnce are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+3.0.3 / 2020-03-30
+==================
+
+  * Support string array traits when either `traitsToIncrement` or `traitsToSetOnce` is set
+
 3.0.2 / 2019-09-16
 ==================
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=3.0.2-SNAPSHOT
+VERSION=3.0.3-SNAPSHOT
 
 POM_ARTIFACT_ID=amplitude
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -258,6 +258,9 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
       String stringValue = String.valueOf(value);
       identify.set(key, stringValue);
     }
+    if (value instanceof String[]) {
+      identify.set(key, (String[]) value);
+    }
   }
 
   @Override

--- a/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/amplitude/AmplitudeTest.java
@@ -455,6 +455,7 @@ public class AmplitudeTest {
         .putValue("traitsToIncrement", Arrays.asList("double", "float", "integer", "long", "string"));
     integration.traitsToIncrement = getStringSet(settings, "traitsToIncrement");
 
+    String[] strArray = new String[]{"test"};
     double d = 100.0;
     float f = 100.0f;
     int i = 100;
@@ -463,6 +464,7 @@ public class AmplitudeTest {
 
     Traits traits = createTraits("foo")
         .putValue("anonymousId", "anonId")
+        .putValue("array", strArray)
         .putValue("double", d)
         .putValue("float", f)
         .putValue("integer", i)
@@ -474,6 +476,7 @@ public class AmplitudeTest {
     Identify expectedIdentify = new Identify();
     expectedIdentify.set("anonymousId", "anonId");
     expectedIdentify.set("userId", "foo");
+    expectedIdentify.set("array", strArray);
     expectedIdentify.add("double", d);
     expectedIdentify.add("float", f);
     expectedIdentify.add("integer", i);
@@ -489,6 +492,7 @@ public class AmplitudeTest {
         .putValue("traitsToSetOnce", Arrays.asList("double", "float", "integer", "long", "string"));
     integration.traitsToSetOnce = getStringSet(settings, "traitsToSetOnce");
 
+    String[] strArray = new String[]{"test"};
     double d = 100.0;
     float f = 100.0f;
     int i = 100;
@@ -497,6 +501,7 @@ public class AmplitudeTest {
 
     Traits traits = createTraits("foo")
         .putValue("anonymousId", "anonId")
+        .putValue("array", strArray)
         .putValue("double", d)
         .putValue("float", f)
         .putValue("integer", i)
@@ -509,6 +514,7 @@ public class AmplitudeTest {
     Identify expectedIdentify = new Identify();
     expectedIdentify.set("anonymousId", "anonId");
     expectedIdentify.set("userId", "foo");
+    expectedIdentify.set("array", strArray);
     expectedIdentify.setOnce("double", d);
     expectedIdentify.setOnce("float", f);
     expectedIdentify.setOnce("integer", i);


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for string arrays in traits when either traitsToIncrement or traitsToSetOnce are set

**Are there breaking changes in this PR?**
no

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Yes


Running the current version of code I sent a request via the amplitude sdk with the userId 'dog', setting a 'dog' string array property


<img width="508" alt="Screen Shot 2020-02-28 at 11 22 29 AM" src="https://user-images.githubusercontent.com/6434313/75707599-02bb1c00-5c74-11ea-9840-69364583ced6.png">
<img width="1655" alt="Screen Shot 2020-02-28 at 11 19 24 AM" src="https://user-images.githubusercontent.com/6434313/75708071-ed92bd00-5c74-11ea-8a40-db006a7c56e0.png">

Above you can observe the absence of the property

Then I made the code change in this PR and sent another request 'zebra' with a string array property 'zebra'

<img width="508" alt="Screen Shot 2020-02-28 at 11 22 20 AM" src="https://user-images.githubusercontent.com/6434313/75707629-14042880-5c74-11ea-8d11-2f67dfd6dac3.png">
<img width="1673" alt="Screen Shot 2020-02-28 at 11 19 33 AM" src="https://user-images.githubusercontent.com/6434313/75707638-1797af80-5c74-11ea-88ea-64097bd1e25e.png">

In this screenshot below we can observe that the property 'dog' is absent whereas the property 'dog' is not

<img width="1669" alt="Screen Shot 2020-02-28 at 11 21 54 AM" src="https://user-images.githubusercontent.com/6434313/75708132-131fc680-5c75-11ea-9b34-34bca3bbf22b.png">


**Any background context you want to provide?**
This PR was prompted by the change made here by zenly in their fork 
https://github.com/znly/analytics-android-integration-amplitude/commit/45d22e851dfa0c8915fa4dd8e813e262884a7470

I tested this change using the sample app in the analytics-android repo and made some changes including importing this repo as a module, the code i tested with is represented here https://github.com/segmentio/analytics-android/commit/76b60b86dbf661baa5be34b67e1219253689ec06

**Is there parity with the server-side/analytics.js integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
no

**What are the relevant tickets?**
https://segment.atlassian.net/browse/LIB-1605

**Link to CC ticket**
CC in this PR

**List all the tests accounts you have used to make sure this change works**
My own amplitude test account

**Helpful Docs**


**Version for this change**
