### PR TITLE
Fix issue while reading values from Group Payload in group() call

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeIntegration.java
@@ -92,7 +92,7 @@ public class AmplitudeIntegration extends Integration<AmplitudeClient> {
     trackNamedPages = settings.getBoolean("trackNamedPages", false);
     useLogRevenueV2 = settings.getBoolean("useLogRevenueV2", false);
     groupTypeTrait = settings.getString("groupTypeTrait");
-    groupValueTrait = settings.getString("groupTypeValue");
+    groupValueTrait = settings.getString("groupValueTrait");
     traitsToIncrement = getStringSet(settings, "traitsToIncrement");
     traitsToSetOnce = getStringSet(settings, "traitsToSetOnce");
     logger = analytics.logger(AMPLITUDE_KEY);


### PR DESCRIPTION
**What does this PR do?**
Fix issue while reading values from Group Payload in group() call

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
![Screenshot 2020-11-19 at 8 21 39 PM](https://user-images.githubusercontent.com/10864476/99718830-82726a80-2ad1-11eb-8eed-4a2212cb262b.png)

**Any background context you want to provide?**
Amplitude group call with `group_type` and `group_value` traits wasn't working without this fix.

**Is there parity with the server-side/analytics.js integration (if applicable)?**
No.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
No.

**What are the relevant tickets?**
N/A

**Link to CC ticket**
N/A

**List all the tests accounts you have used to make sure this change works**
N/A

**Helpful Docs**
N/A

**Version for this change**
Not sure.