### PR TITLE
Add Amplitude SessionId Middleware

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeSessionId.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeSessionId.java
@@ -1,0 +1,114 @@
+package com.segment.analytics.android.integrations.amplitude;
+
+import com.segment.analytics.Middleware;
+import com.segment.analytics.ValueMap;
+import com.segment.analytics.integrations.AliasPayload;
+import com.segment.analytics.integrations.BasePayload;
+import com.segment.analytics.integrations.GroupPayload;
+import com.segment.analytics.integrations.IdentifyPayload;
+import com.segment.analytics.integrations.ScreenPayload;
+import com.segment.analytics.integrations.TrackPayload;
+
+import java.util.Timer;
+import java.util.Calendar;
+import java.util.TimerTask;
+
+public class AmplitudeSessionId implements Middleware {
+
+  private final static String KEY = "Actions Amplitude";
+  private boolean active = false;
+
+  private final static long FIRE_TIME = 300000;
+
+  private TimerTask timer;
+
+  private long sessionID = -1;
+
+
+  @Override
+  public void intercept(Chain chain) {
+    BasePayload payload = chain.payload();
+
+    switch (payload.type()) {
+      case alias:
+        payload = alias((AliasPayload) payload);
+        break;
+      case group:
+        payload = group((GroupPayload) payload);
+        break;
+      case identify:
+        payload = identify((IdentifyPayload) payload);
+        break;
+      case screen:
+        payload = screen((ScreenPayload) payload);
+        break;
+      case track:
+        payload = track((TrackPayload) payload);
+        break;
+    }
+
+    chain.proceed(payload);
+  }
+
+  private BasePayload insertSession(BasePayload payload) {
+    return payload
+        .toBuilder()
+        .integration(KEY, new ValueMap()
+            .putValue("session_id", sessionID))
+        .build();
+  }
+
+  private BasePayload alias(AliasPayload payload) {
+    return insertSession(payload);
+  }
+
+  private BasePayload group(GroupPayload payload) {
+    return insertSession(payload);
+  }
+
+  private BasePayload identify(IdentifyPayload payload) {
+    return insertSession(payload);
+  }
+
+  private BasePayload screen(ScreenPayload payload) {
+    return insertSession(payload);
+  }
+
+  private BasePayload track(TrackPayload payload) {
+    if (payload.event().equals("Application Backgrounded")) {
+      onBackground();
+    } else if (payload.event().equals("Application Opened")) {
+      onForeground();
+    }
+    return insertSession(payload);
+  }
+
+  private void onBackground() {
+    stopTimer();
+  }
+
+  private void onForeground() {
+    startTimer();
+  }
+
+  private void startTimer() {
+    // Set the session id
+    sessionID = Calendar.getInstance().getTimeInMillis();
+
+    timer = new TimerTask() {
+      @Override
+      public void run() {
+        stopTimer();
+        startTimer();
+      }
+    };
+    new Timer().schedule(timer, FIRE_TIME);
+  }
+
+  private void stopTimer() {
+    if (timer != null) {
+      timer.cancel();
+    }
+    sessionID = -1;
+  }
+}

--- a/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeSessionId.java
+++ b/src/main/java/com/segment/analytics/android/integrations/amplitude/AmplitudeSessionId.java
@@ -86,8 +86,8 @@ public class AmplitudeSessionId implements Middleware {
 
   private long getSessionId() {
     if (sessionID != -1) {
-      // if sessionId is -1, then we reset to curTime (essentially creating a new session)
-      // TODO ask cody if -1 has a special value
+      // if sessionId is not -1, then we reset to curTime (essentially creating a new session)
+      // https://help.amplitude.com/hc/en-us/articles/115002323627-Tracking-sessions-in-Amplitude#h_a832c1ce-717a-4ab3-b205-9d7ed418ef1a
       long curTime = Calendar.getInstance().getTimeInMillis();
       if (curTime - sessionID >= FIRE_TIME) { // if FIRE_TIME ms have elapsed, reset the sessionId
         sessionID = curTime; // reset sessionId


### PR DESCRIPTION
**What does this PR do?**
With the release of destination actions for [Amplitude](https://segment.com/docs/connections/destinations/catalog/actions-amplitude/) users can now use this SessionId Middleware to send data to Amplitude via cloud-mode and still track sessions for users

**Are there breaking changes in this PR?**
No breaking changes

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Tested via test account ensuring that new sessions are recorded without sending events in device-mode, rather sending in cloud-mode enhanced by said middleware

**Helpful Docs**
https://segment.com/docs/connections/destinations/catalog/actions-amplitude/